### PR TITLE
Fixed broken codeclimate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the source-code for: https://cli.fyi
 **Cli.fyi** lets you to quickly retrieve information about emails, IP addresses, URLs and lots more from the command line (or Browser)
 
  [![Build Status](https://travis-ci.org/daveearley/cli.fyi.svg?branch=master)](https://travis-ci.org/daveearley/cli.fyi)
- [![Maintainability](https://api.codeclimate.com/v1/badges/25ee700a43f2a199d98b/maintainability)](https://codeclimate.com/github/daveearley/cli.fyi/maintainability)
+ [![Maintainability](https://api.codeclimate.com/v1/badges/25ee700a43f2a199d98b/maintainability)](https://codeclimate.com/github/daveearley/cli.fyi)
 ## Supported Queries
 - Crypto Currency Prices
 - Email Address Information


### PR DESCRIPTION
Link to codeclimate returns a 404, for other repositories when adding the `/maintainability` part in the url it seems to just redirect to the overview. 

Is it a paid feature or something maybe?